### PR TITLE
Add WordPress.org Plugin Check workflow

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -1,0 +1,33 @@
+name: 'WordPress.org Plugin Check'
+on: # rebuild any PRs and main branch changes
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v5
+
+        - name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: '8.3'
+            coverage: none
+            tools: wp-cli
+
+        - name: Install latest version of dist-archive-command
+          run: wp package install wp-cli/dist-archive-command:v3.1.0
+
+        - name: Build plugin
+          run: |
+            wp dist-archive . ./${{ github.event.repository.name }}.zip
+            mkdir build
+            unzip ${{ github.event.repository.name }}.zip -d build
+
+        - name: Run plugin check
+          uses: wordpress/plugin-check-action@v1.1.5
+          with:
+            build-dir: './build/${{ github.event.repository.name }}'
+            exclude-checks: |
+              direct_file_access

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -22,12 +22,12 @@ jobs:
         - name: Build plugin
           run: |
             wp dist-archive . ./${{ github.event.repository.name }}.zip
-            mkdir build
-            unzip ${{ github.event.repository.name }}.zip -d build
+            mkdir plugin-check-build
+            unzip ${{ github.event.repository.name }}.zip -d plugin-check-build
 
         - name: Run plugin check
           uses: wordpress/plugin-check-action@v1.1.5
           with:
-            build-dir: './build/${{ github.event.repository.name }}'
+            build-dir: './plugin-check-build/${{ github.event.repository.name }}'
             exclude-checks: |
               direct_file_access


### PR DESCRIPTION
## Summary
- Add `.github/workflows/plugin-check.yml` that runs the official [`wordpress/plugin-check-action`](https://github.com/WordPress/plugin-check-action) on every PR
- Builds the plugin via `wp dist-archive` (respecting the existing `.distignore`) and scans the built artifact, so results mirror what WordPress.org reviewers see
- Mirrors the setup used in [progress-planner](https://github.com/ProgressPlanner/progress-planner/blob/44c90aadc2d78ee31faae195191169c903f36108/.github/workflows/plugin-check.yml), with `direct_file_access` excluded

## Test plan
- [ ] CI runs the new `WordPress.org Plugin Check` job on this PR
- [ ] Job completes without errors unrelated to the plugin code
- [ ] Review reported issues (if any) and decide on follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)