### PR TITLE
Add source code repository link to readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ composer phpstan          # Run PHPStan
 ## Support
 
 - Plugin page: https://wordpress.org/plugins/brand-assets/
+- Source code: https://github.com/ProgressPlanner/brand-assets
 - Documentation: https://progressplanner.com/plugins/brand-assets/
 - Issues: https://github.com/ProgressPlanner/brand-assets/issues
 - Team Progress Planner: https://progressplanner.com/

--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,12 @@ Yes. The settings screen includes controls for colors, spacing, borders, max wid
 
 Yes. Brand Assets includes a pre-built block pattern with logo sections, downloadable asset links, a brand color palette area, and typography examples so you can start faster.
 
+== Support ==
+
+- Source code: https://github.com/ProgressPlanner/brand-assets
+- Documentation: https://progressplanner.com/plugins/brand-assets/
+- Issues: https://github.com/ProgressPlanner/brand-assets/issues
+
 == Screenshots ==
 
 1. Brand Assets settings screen for choosing the brand assets page, logo selector, and popover text.


### PR DESCRIPTION
## Summary
- Add GitHub repository link to the Support section in README.md and readme.txt
- Addresses wp.org plugin review feedback requiring publicly accessible source code to be documented in the readme

## Test plan
- [ ] Verify readme.txt renders correctly on wp.org (Support section appears before Screenshots)
- [ ] Verify README.md Support section includes the source code link

🤖 Generated with [Claude Code](https://claude.com/claude-code)