### PR TITLE
Add WordPress.org SVN deploy workflows

### DIFF
--- a/.github/workflows/asset-deploy.yml
+++ b/.github/workflows/asset-deploy.yml
@@ -1,0 +1,16 @@
+name: Plugin asset/readme update
+on:
+  push:
+    branches:
+    - main
+jobs:
+  asset_deploy:
+    name: Push to main
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - name: WordPress.org plugin asset/readme update
+      uses: 10up/action-wordpress-plugin-asset-update@develop
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/asset-deploy.yml
+++ b/.github/workflows/asset-deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:
 jobs:
   asset_deploy:
     name: Push to main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy to WordPress.org repository
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  deploy_to_wordpress_org:
+    name: Deploy release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build assets
+        run: npm run build
+
+      - name: WordPress plugin deploy
+        id: deploy
+        uses: 10up/action-wordpress-plugin-deploy@develop
+        with:
+          generate-zip: true
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+
+      - name: Upload release asset
+        uses: Shopify/upload-to-release@master
+        with:
+          name: ${{ github.event.repository.name }}.zip
+          path: ${{ steps.deploy.outputs.zip-path }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          content-type: application/zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy to WordPress.org repository
 on:
   release:
     types: [released]
+  workflow_dispatch:
 
 jobs:
   deploy_to_wordpress_org:
@@ -34,6 +35,7 @@ jobs:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
 
       - name: Upload release asset
+        if: github.event_name == 'release'
         uses: Shopify/upload-to-release@master
         with:
           name: ${{ github.event.repository.name }}.zip


### PR DESCRIPTION
## Summary

- Add `.github/workflows/deploy.yml` — release-triggered workflow that builds JS assets (`npm ci && npm run build`), deploys the plugin to the wp.org SVN repo via `10up/action-wordpress-plugin-deploy@develop`, and uploads the generated zip to the GitHub release.
- Add `.github/workflows/asset-deploy.yml` — push-to-`main` workflow that syncs `.wordpress-org/` assets and `readme.txt` to the wp.org SVN `assets/` and trunk via `10up/action-wordpress-plugin-asset-update@develop`.

Adapted from the equivalent workflows in `ProgressPlanner/progress-planner`. The deploy workflow adds a Node build step here because Brand Assets ships a Gutenberg block whose `build/` directory is gitignored — `register_block_type()` loads it at runtime, so it must be generated in CI before SVN push. `vendor/` is already excluded via `.distignore` and contains dev-only tooling, so no composer step is needed.

## Test plan

- [x] Confirm `SVN_USERNAME` and `SVN_PASSWORD` repository secrets are present.
- [ ] Merge to `main` and watch `asset-deploy.yml` run successfully (pushes `.wordpress-org/` + `readme.txt` to wp.org).
- [ ] Publish a `1.0.0` GitHub Release and watch `deploy.yml` build, deploy to SVN trunk + tags/1.0.0, and attach the zip to the release.
- [ ] Verify the deployed plugin on wp.org contains `build/` but not `src/`, `node_modules/`, or `vendor/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)