### PR TITLE
Add WordPress.org SVN deploy workflows to main branch

### DIFF
--- a/.github/workflows/asset-deploy.yml
+++ b/.github/workflows/asset-deploy.yml
@@ -1,0 +1,16 @@
+name: Plugin asset/readme update
+on:
+  push:
+    branches:
+    - main
+jobs:
+  asset_deploy:
+    name: Push to main
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - name: WordPress.org plugin asset/readme update
+      uses: 10up/action-wordpress-plugin-asset-update@develop
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/asset-deploy.yml
+++ b/.github/workflows/asset-deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:
 jobs:
   asset_deploy:
     name: Push to main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy to WordPress.org repository
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  deploy_to_wordpress_org:
+    name: Deploy release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build assets
+        run: npm run build
+
+      - name: WordPress plugin deploy
+        id: deploy
+        uses: 10up/action-wordpress-plugin-deploy@develop
+        with:
+          generate-zip: true
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+
+      - name: Upload release asset
+        uses: Shopify/upload-to-release@master
+        with:
+          name: ${{ github.event.repository.name }}.zip
+          path: ${{ steps.deploy.outputs.zip-path }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          content-type: application/zip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy to WordPress.org repository
 on:
   release:
     types: [released]
+  workflow_dispatch:
 
 jobs:
   deploy_to_wordpress_org:
@@ -34,6 +35,7 @@ jobs:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
 
       - name: Upload release asset
+        if: github.event_name == 'release'
         uses: Shopify/upload-to-release@master
         with:
           name: ${{ github.event.repository.name }}.zip


### PR DESCRIPTION
## Summary

Release merge: `develop` → `main` for the initial 1.0.0 wp.org ship.

Brings in:
- WordPress.org SVN deploy workflows (#30) — `deploy.yml` (release-triggered, manual-dispatchable) and `asset-deploy.yml` (push-to-main, manual-dispatchable).

## Release flow

Once this merges:
1. `asset-deploy.yml` fires automatically on the push to `main` and syncs `.wordpress-org/` + `readme.txt` to wp.org.
2. Trigger `deploy.yml` manually from the Actions tab (branch `main`) to build and push the plugin code to SVN trunk + `tags/1.0.0`. The existing 1.0.0 GitHub release predates the workflow, so manual dispatch is used instead of recreating the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)