### PR TITLE
Sync package-lock.json with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "brand-assets",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "brand-assets",
-			"version": "0.1.0",
+			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/scripts": "^30.4.0"
@@ -16011,6 +16011,22 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/plur": {


### PR DESCRIPTION
## Summary

The deploy workflow's `npm ci` step failed because the lockfile was out of sync with `package.json` (missing `fsevents@2.3.2` and several other entries). Regenerated locally with `npm install` so CI's strict `npm ci` can resolve the dependency tree.

This unblocks the WordPress.org SVN deploy workflow added in #30.

Failing run for reference: https://github.com/ProgressPlanner/brand-assets/actions/runs/25109213826

## Test plan

- [ ] After merge to develop → main, re-run `deploy.yml` manually.
- [ ] `Install Node dependencies` step (`npm ci`) succeeds.
- [ ] `Build assets` step produces `build/` containing the compiled block.
- [ ] `WordPress plugin deploy` step pushes to wp.org SVN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)