### PR TITLE
Release: sync package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "brand-assets",
-	"version": "0.1.0",
+	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "brand-assets",
-			"version": "0.1.0",
+			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/scripts": "^30.4.0"
@@ -16011,6 +16011,22 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/plur": {


### PR DESCRIPTION
## Summary

Brings the lockfile sync from #32 into main so `deploy.yml`'s `npm ci` step can succeed when re-triggered.

This is the only delta vs main right now.

## After merging

1. Merge fires `asset-deploy.yml` automatically (pushes `.wordpress-org/` + `readme.txt` to wp.org).
2. Manually trigger `deploy.yml` from Actions → Run workflow → Branch: main, to push 1.0.0 to SVN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)